### PR TITLE
fix #1 - bullet occasionally persisting after collision with enemy

### DIFF
--- a/MTD/Game.cpp
+++ b/MTD/Game.cpp
@@ -170,15 +170,16 @@ void Game::update()
 		unsigned int bulletNumber{ 0u };
 		for (auto& bullet : bullets)
 		{
-			if (!bullet.isAlive())
-				continue;
-			bulletHalfSize = bullet.getSize() / 2.0;
-			bulletBoundingBox.setLeftBottom(bullet.getPosition() - bulletHalfSize);
-			bulletBoundingBox.setRightTop(bullet.getPosition() + bulletHalfSize);
-			if (enemyBoundingBox.overlaps(bulletBoundingBox))
+			if (bullet.isAlive())
 			{
-				addElementToVectorIfUnique(enemiesToRemove, enemy - enemies.begin());
-				addElementToVectorIfUnique(bulletsToRemove, bulletNumber);
+				bulletHalfSize = bullet.getSize() / 2.0;
+				bulletBoundingBox.setLeftBottom(bullet.getPosition() - bulletHalfSize);
+				bulletBoundingBox.setRightTop(bullet.getPosition() + bulletHalfSize);
+				if (enemyBoundingBox.overlaps(bulletBoundingBox))
+				{
+					addElementToVectorIfUnique(enemiesToRemove, enemy - enemies.begin());
+					addElementToVectorIfUnique(bulletsToRemove, bulletNumber);
+				}
 			}
 			++bulletNumber;
 		}


### PR DESCRIPTION
stops bullets occasionally persisting after a collision with an enemy.
The problem was that when multiple bullets existed, the bullet index
(bulletNumber) was not being increased if the first (or a previous)
bullet was "not alive". bulletNumber is now increased whether alive or
not.
